### PR TITLE
Added error handling for maquillalia and Sephora

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,9 +1143,11 @@ name = "scrapped-webs"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
+ "anyhow",
  "reqwest",
  "scraper",
  "strsim",
+ "thiserror",
 ]
 
 [[package]]
@@ -1355,6 +1363,26 @@ name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinyvec"

--- a/scrapped_webs/Cargo.toml
+++ b/scrapped_webs/Cargo.toml
@@ -9,3 +9,5 @@ ansi_term = "0.12.1"
 reqwest = {version = "0.11", features = ["blocking"]}
 scraper = "0.13.0"
 strsim = "0.10.0"
+anyhow = "1.0"
+thiserror = "1.0"

--- a/scrapped_webs/src/helper.rs
+++ b/scrapped_webs/src/helper.rs
@@ -154,6 +154,7 @@ pub mod scrapping {
     /// String - if found
     /// HtmlSearchError::ElementNotFound - if not found the selector
     /// HtmlSearchError::AttributeNotFound - if not found the attribute
+    #[allow(dead_code)]
     pub fn has_html_selector(element: &ElementRef, selector: &str) -> bool {
         element
             .select(&scraper::Selector::parse(selector).unwrap())

--- a/scrapped_webs/src/product.rs
+++ b/scrapped_webs/src/product.rs
@@ -9,23 +9,23 @@ use crate::helper::utilities;
 #[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
 pub struct Tone {
     /// Name of the tone.
-    name: String,
+    pub name: Option<String>,
     /// The standard price.
-    price_standard: f32,
+    pub price_standard: Option<f32>,
     /// The price in case it is on sale.
-    price_sales: Option<f32>,
+    pub price_sales: Option<f32>,
     /// Available flag.
-    available: bool,
+    pub available: bool,
     /// Possible url if it is not directly in the same webpage.
-    url: Option<String>,
+    pub url: Option<String>,
     /// Possible rating.
-    rating: Option<f32>,
+    pub rating: Option<f32>,
 }
 
 impl Tone {
     pub fn new(
-        name: String,
-        price_standard: f32,
+        name: Option<String>,
+        price_standard: Option<f32>,
         price_sales: Option<f32>,
         available: bool,
         url: Option<String>,
@@ -51,26 +51,26 @@ impl Tone {
             true => out.push_str("✔️   "),
             false => out.push_str("❌   "),
         }
-        out.push_str(format!("{} - ", self.name).as_str());
+        out.push_str(format!("{} - ", self.name.as_ref().unwrap()).as_str());
         match self.price_sales {
             Some(price_sales) => {
                 let strikedthrought_price = ansi_term::Style::new()
                     .strikethrough()
-                    .paint(self.price_standard.to_string())
+                    .paint(self.price_standard.unwrap().to_string())
                     .to_string();
                 out.push_str(
                     format!(
                         "{}€ {}€({}%)",
                         strikedthrought_price,
                         price_sales,
-                        utilities::discount(self.price_standard, self.price_sales)
+                        utilities::discount(self.price_standard.unwrap(), self.price_sales)
                             .unwrap()
                             .1
                     )
                     .as_str(),
                 )
             }
-            None => out.push_str(format!("{}€", self.price_standard).as_str()),
+            None => out.push_str(format!("{}€", self.price_standard.unwrap()).as_str()),
         }
         if let Some(rating) = self.rating {
             out.push_str(format!(" - {rating}⭐").as_str())
@@ -83,65 +83,16 @@ impl Tone {
         if self.price_sales.is_some() {
             self.price_sales.unwrap()
         } else {
-            self.price_standard
+            self.price_standard.unwrap()
         }
-    }
-
-    /// Returns the name of the product.
-    pub fn name(&self) -> &String {
-        &self.name
-    }
-    /// Returns the standard price.
-    pub fn price_standard(&self) -> f32 {
-        self.price_standard
-    }
-    /// Returns the price if it is on sale.
-    pub fn price_sales(&self) -> Option<f32> {
-        self.price_sales
-    }
-    /// Returns the available.
-    pub fn available(&self) -> bool {
-        self.available
-    }
-    /// Returns the url.
-    pub fn url(&self) -> Option<String> {
-        self.url.clone()
-    }
-    /// Returns the rating.
-    pub fn rating(&self) -> Option<f32> {
-        self.rating
-    }
-    /// Sets the name of the product.
-    pub fn set_name(&mut self, name: String) {
-        self.name = name;
-    }
-    /// Sets the standard price.
-    pub fn set_price_standard(&mut self, price_standard: f32) {
-        self.price_standard = price_standard;
-    }
-    /// Sets the price if it is on sale.
-    pub fn set_price_sales(&mut self, price_sales: Option<f32>) {
-        self.price_sales = price_sales;
-    }
-    /// Sets if the product its available.
-    pub fn set_available(&mut self, available: bool) {
-        self.available = available;
-    }
-    /// Sets the URL.
-    pub fn set_url(&mut self, url: Option<String>) {
-        self.url = url;
-    }
-    /// Sets the rating.
-    pub fn set_rating(&mut self, rating: Option<f32>) {
-        self.rating = rating;
     }
 }
 
 impl Display for Tone {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut out: String = String::new();
-        out.push_str(format!("Name: {}", self.name()).as_str());
-        out.push_str(format!("\nPrice: {}", self.price_standard()).as_str());
+        out.push_str(format!("Name: {}", self.name.as_ref().unwrap()).as_str());
+        out.push_str(format!("\nPrice: {}", self.price_standard.unwrap()).as_str());
         if let Some(price_sales) = self.price_sales {
             out.push_str(format!("\nPrice on sale: {price_sales}").as_str());
         }
@@ -154,23 +105,23 @@ impl Display for Tone {
 #[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
 pub struct Product {
     /// The product name.
-    name: String,
+    pub name: String,
     /// The brand name.
-    brand: String,
+    pub brand: Option<String>,
     /// The link to the product.
-    link: String,
+    pub link: String,
     /// The standard price.
-    price_standard: f32,
+    pub price_standard: Option<f32>,
     /// The price in case it is on sale.
-    price_sales: Option<f32>,
+    pub price_sales: Option<f32>,
     /// The ratings between 0-5.
-    rating: Option<f32>,
+    pub rating: Option<f32>,
     /// Similarity between the product name to search and the one found.
-    similarity: f32,
+    pub similarity: f32,
     /// Available of the product.
-    available: bool,
+    pub available: bool,
     /// The list of tones for this product.
-    tones: Option<Vec<Tone>>,
+    pub tones: Option<Vec<Tone>>,
 }
 
 impl Product {
@@ -188,9 +139,9 @@ impl Product {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
-        brand: String,
+        brand: Option<String>,
         link: String,
-        price_standard: f32,
+        price_standard: Option<f32>,
         price_sales: Option<f32>,
         tones: Option<Vec<Tone>>,
         rating: Option<f32>,
@@ -217,7 +168,7 @@ impl Product {
     pub fn terminal_format(&self) -> String {
         let mut out: String = String::new();
         out.push_str(format!("- {}. ", self.similarity_formatted()).as_str());
-        out.push_str(format!("{} - {} - ", self.name, self.brand).as_str());
+        out.push_str(format!("{} - {} - ", self.name, self.brand.as_ref().unwrap()).as_str());
 
         match self.tones.as_ref() {
             // If we have tones, look for the lowest and highest price
@@ -239,21 +190,21 @@ impl Product {
                 Some(price_sales) => {
                     let strikedthrought_price = ansi_term::Style::new()
                         .strikethrough()
-                        .paint(self.price_standard.to_string())
+                        .paint(self.price_standard.unwrap().to_string())
                         .to_string();
                     out.push_str(
                         format!(
                             "{}€ {}€({}%)",
                             strikedthrought_price,
                             price_sales,
-                            utilities::discount(self.price_standard, self.price_sales)
+                            utilities::discount(self.price_standard.unwrap(), self.price_sales)
                                 .unwrap()
                                 .1
                         )
                         .as_str(),
                     )
                 }
-                None => out.push_str(format!("{}€", self.price_standard).as_str()),
+                None => out.push_str(format!("{}€", self.price_standard.unwrap()).as_str()),
             },
         }
 
@@ -271,78 +222,6 @@ impl Product {
         format!("{:.2}%", self.similarity * 100.0)
     }
 
-    /// Returns the name of the product.
-    pub fn name(&self) -> &String {
-        &self.name
-    }
-    /// Returns the brand of the product.
-    pub fn brand(&self) -> &String {
-        &self.brand
-    }
-    /// Returns the link to the product.
-    pub fn link(&self) -> &String {
-        &self.link
-    }
-    /// Returns the standard price.
-    pub fn price_standard(&self) -> f32 {
-        self.price_standard
-    }
-    /// Returns the price if it is on sale.
-    pub fn price_sales(&self) -> Option<f32> {
-        self.price_sales
-    }
-    /// Returns the tones of the product.
-    pub fn tones(&self) -> Option<&Vec<Tone>> {
-        self.tones.as_ref()
-    }
-    /// Returns the rating.
-    pub fn rating(&self) -> Option<f32> {
-        self.rating
-    }
-    /// Returns the similarity.
-    pub fn similarity(&self) -> f32 {
-        self.similarity
-    }
-    /// Returns the availability.
-    pub fn available(&self) -> bool {
-        self.available
-    }
-    /// Sets the name of the product.
-    pub fn set_name(&mut self, name: String) {
-        self.name = name;
-    }
-    /// Sets the brand of the product.
-    pub fn set_brand(&mut self, brand: String) {
-        self.brand = brand;
-    }
-    /// Sets the link to the product.
-    pub fn set_link(&mut self, link: String) {
-        self.link = link;
-    }
-    /// Sets the standard price.
-    pub fn set_price_standard(&mut self, price_standard: f32) {
-        self.price_standard = price_standard;
-    }
-    /// Sets the price if it is on sale.
-    pub fn set_price_sales(&mut self, price_sales: Option<f32>) {
-        self.price_sales = price_sales
-    }
-    /// Sets the tones of the product.
-    pub fn set_tones(&mut self, tones: Option<Vec<Tone>>) {
-        self.tones = tones;
-    }
-    /// Sets the rating.
-    pub fn set_rating(&mut self, rating: Option<f32>) {
-        self.rating = rating;
-    }
-    /// Sets the similarity.
-    pub fn set_similarity(&mut self, similarity: f32) {
-        self.similarity = similarity;
-    }
-    /// Sets the availability.
-    pub fn set_available(&mut self, set_available: bool) {
-        self.available = set_available;
-    }
     /// Adds a new Tone.
     pub fn add_tone(&mut self, tone: Tone) {
         if self.tones.is_none() {
@@ -355,19 +234,19 @@ impl Product {
 impl Display for Product {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut out: String = String::new();
-        out.push_str(format!("Name: {}", self.name()).as_str());
-        out.push_str(format!("\nBrand: {}", self.brand()).as_str());
-        out.push_str(format!("\nLink: {}", self.link()).as_str());
-        out.push_str(format!("\nPrice: {}", self.price_standard()).as_str());
-        if let Some(price_sales) = self.price_sales() {
+        out.push_str(format!("Name: {}", self.name).as_str());
+        out.push_str(format!("\nBrand: {}", self.brand.as_ref().unwrap()).as_str());
+        out.push_str(format!("\nLink: {}", self.link).as_str());
+        out.push_str(format!("\nPrice: {}", self.price_standard.unwrap()).as_str());
+        if let Some(price_sales) = self.price_sales {
             out.push_str(format!("\nPrice on sale: {price_sales}").as_str());
         }
-        if let Some(rating) = self.rating() {
+        if let Some(rating) = self.rating {
             out.push_str(format!("\nRating: {rating}").as_str());
         }
-        out.push_str(format!("\nSimilarity: {}", self.similarity()).as_str());
-        out.push_str(format!("\nAvailable: {}", self.available()).as_str());
-        if let Some(tones) = self.tones() {
+        out.push_str(format!("\nSimilarity: {}", self.similarity).as_str());
+        out.push_str(format!("\nAvailable: {}", self.available).as_str());
+        if let Some(tones) = self.tones.as_ref() {
             out.push_str(format!("\nTones: {tones:#?}").as_str());
         }
 
@@ -382,8 +261,8 @@ mod tests {
     /// Tests the Tone::new function.
     #[test]
     fn tone_instantiation_getters_and_setters() {
-        let name: String = String::from("Tone1");
-        let price_standard: f32 = 50.0;
+        let name: Option<String> = Some(String::from("Tone1"));
+        let price_standard: Option<f32> = Some(50.0);
         let price_sales: Option<f32> = Some(25.0);
         let available: bool = true;
         let url: Option<String> = Some(String::from("www.tone.es"));
@@ -398,12 +277,12 @@ mod tests {
         );
 
         // Getters
-        assert_eq!(*tone.name(), name);
-        assert_eq!(tone.price_standard(), price_standard);
-        assert_eq!(tone.price_sales().unwrap(), price_sales.unwrap());
-        assert_eq!(tone.available(), available);
-        assert_eq!(tone.url(), url);
-        assert_eq!(tone.rating(), rating);
+        assert_eq!(*tone.name.unwrap(), name.unwrap());
+        assert_eq!(tone.price_standard.unwrap(), price_standard.unwrap());
+        assert_eq!(tone.price_sales.unwrap(), price_sales.unwrap());
+        assert_eq!(tone.available, available);
+        assert_eq!(tone.url.unwrap(), url.unwrap());
+        assert_eq!(tone.rating.unwrap(), rating.unwrap());
 
         // Setters
         let set_name = String::from("Tone2");
@@ -413,12 +292,12 @@ mod tests {
         let set_url: Option<String> = Some(String::from("www.tone2.es"));
         let set_rating: Option<f32> = Some(4.0);
 
-        tone.set_name(set_name.clone());
-        tone.set_price_standard(set_price_standard);
-        tone.set_price_sales(set_price_sales.clone());
-        tone.set_available(set_available);
-        tone.set_url(set_url.clone());
-        tone.set_rating(set_rating.clone());
+        tone.name = Some(set_name.clone());
+        tone.price_standard = Some(set_price_standard);
+        tone.price_sales = set_price_sales.clone();
+        tone.available = set_available;
+        tone.url = set_url.clone();
+        tone.rating = set_rating.clone();
 
         println!("Testing Debug trait implementation for Tone: {:?}", tone);
         println!("Testing Display trait implementation for Tone: {}", tone);
@@ -428,10 +307,10 @@ mod tests {
     #[test]
     fn product_instantiation_getters_and_setters() {
         let name: String = String::from("Test");
-        let brand: String = String::from("Test Brand");
+        let brand: Option<String> = Some(String::from("Test Brand"));
         let link: String = String::from("http://test.es");
-        let tone_name: String = String::from("Tone 1");
-        let price_standard: f32 = 50.0;
+        let tone_name: Option<String> = Some(String::from("Tone 1"));
+        let price_standard: Option<f32> = Some(50.0);
         let price_sales: Option<f32> = Some(25.0);
         let available: bool = true;
         let url: Option<String> = Some(String::from("www.tone.es"));
@@ -459,40 +338,76 @@ mod tests {
         );
 
         // Getters
-        assert_eq!(*product.name(), name);
-        assert_eq!(*product.brand(), brand);
-        assert_eq!(*product.link(), link);
-        assert_eq!(product.price_standard(), price_standard);
-        assert_eq!(product.price_sales().unwrap(), price_sales.unwrap());
-        assert_eq!(product.rating().unwrap(), rating.unwrap());
-        assert_eq!(product.similarity(), similarity);
-        assert_eq!(product.available(), available);
+        assert_eq!(*product.name, name);
+        assert_eq!(*product.brand.unwrap(), brand.unwrap());
+        assert_eq!(*product.link, link);
+        assert_eq!(product.price_standard.unwrap(), price_standard.unwrap());
+        assert_eq!(product.price_sales.unwrap(), price_sales.unwrap());
+        assert_eq!(product.rating.unwrap(), rating.unwrap());
+        assert_eq!(product.similarity, similarity);
+        assert_eq!(product.available, available);
 
-        assert_eq!(*product.tones().unwrap().first().unwrap().name(), tone_name);
         assert_eq!(
-            product.tones().unwrap().first().unwrap().price_standard(),
-            price_standard
+            *product
+                .tones
+                .as_ref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .name
+                .as_ref()
+                .unwrap(),
+            tone_name.unwrap()
         );
         assert_eq!(
-            product.tones().unwrap().first().unwrap().price_sales(),
-            price_sales
+            product
+                .tones
+                .as_ref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .price_standard
+                .unwrap(),
+            price_standard.unwrap()
         );
         assert_eq!(
-            product.tones().unwrap().first().unwrap().available(),
+            product
+                .tones
+                .as_ref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .price_sales
+                .unwrap(),
+            price_sales.unwrap()
+        );
+        assert_eq!(
+            product.tones.as_ref().unwrap().first().unwrap().available,
             available
         );
-        assert_eq!(product.tones().unwrap().first().unwrap().url(), url);
         assert_eq!(
-            product.tones().unwrap().first().unwrap().rating(),
-            tone_rating
+            product
+                .tones
+                .as_ref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .url
+                .as_deref()
+                .unwrap(),
+            url.unwrap()
+        );
+        assert_eq!(
+            product.tones.unwrap().first().unwrap().rating.unwrap(),
+            tone_rating.unwrap()
         );
 
         // Setters
         let set_name: String = String::from("Test 2");
-        let set_brand: String = String::from("Test Brand 2");
+        let set_brand: Option<String> = Some(String::from("Test Brand 2"));
         let set_link: String = String::from("http://test2.es");
-        let set_tone_name: String = String::from("Tone 2");
-        let set_price_standard: f32 = 100.0;
+        let set_tone_name: Option<String> = Some(String::from("Tone 2"));
+        let set_price_standard: Option<f32> = Some(100.0);
         let set_price_sales: Option<f32> = Some(50.0);
         let set_available: bool = false;
         let set_url: Option<String> = Some(String::from("www.tone2.es"));
@@ -508,15 +423,15 @@ mod tests {
         let set_rating: Option<f32> = Some(4.0);
         let set_similarity: f32 = 0.75;
 
-        product.set_name(set_name.clone());
-        product.set_brand(set_brand.clone());
-        product.set_link(set_link.clone());
-        product.set_price_standard(set_price_standard);
-        product.set_price_sales(set_price_sales.clone());
-        product.set_tones(set_tones.clone());
-        product.set_rating(set_rating.clone());
-        product.set_similarity(set_similarity);
-        product.set_available(set_available);
+        product.name = set_name.clone();
+        product.brand = set_brand.clone();
+        product.link = set_link.clone();
+        product.price_standard = set_price_standard;
+        product.price_sales = set_price_sales.clone();
+        product.tones = set_tones.clone();
+        product.rating = set_rating.clone();
+        product.similarity = set_similarity;
+        product.available = set_available;
 
         println!(
             "Testing Debug trait implementation for Product: {:?}",
@@ -532,28 +447,28 @@ mod tests {
     #[test]
     fn price_all_paths() {
         // Tone with price on sale.
-        let price_standard: f32 = 10.0;
-        let price_sales: f32 = 5.0;
+        let price_standard: Option<f32> = Some(10.0);
+        let price_sales: Option<f32> = Some(5.0);
         let tone_on_sale: Tone = Tone {
-            name: String::from("Tone 1"),
+            name: Some(String::from("Tone 1")),
             price_standard,
-            price_sales: Some(price_sales),
+            price_sales: price_sales,
             available: true,
             url: None,
             rating: Some(9.5),
         };
-        assert_eq!(tone_on_sale.price(), price_sales);
+        assert_eq!(tone_on_sale.price(), price_sales.unwrap());
 
         // Tone without price on sale.
         let tone: Tone = Tone {
-            name: String::from("Tone 1"),
+            name: Some(String::from("Tone 1")),
             price_standard,
             price_sales: None,
             available: true,
             url: None,
             rating: Some(9.5),
         };
-        assert_eq!(tone.price(), price_standard);
+        assert_eq!(tone.price(), price_standard.unwrap());
     }
 
     /// Tests the function Product::terminal_format without tones and on sale.
@@ -561,9 +476,9 @@ mod tests {
     fn product_format_terminal_without_tones() {
         let product: Product = Product {
             name: String::from("Product 1"),
-            brand: String::from("Brand"),
+            brand: Some(String::from("Brand")),
             link: String::from("http://www.test.com"),
-            price_standard: 10.0,
+            price_standard: Some(10.0),
             price_sales: None,
             rating: Some(9.5),
             similarity: 0.9,
@@ -574,9 +489,9 @@ mod tests {
 
         let product_on_sale: Product = Product {
             name: String::from("Product 1"),
-            brand: String::from("Brand"),
+            brand: Some(String::from("Brand")),
             link: String::from("http://www.test.com"),
-            price_standard: 10.0,
+            price_standard: Some(10.0),
             price_sales: Some(5.0),
             rating: Some(9.5),
             similarity: 0.9,
@@ -591,16 +506,16 @@ mod tests {
     #[test]
     fn product_format_terminal_with_tones() {
         let tone: Tone = Tone {
-            name: String::from("Tone 1"),
-            price_standard: 50.99,
+            name: Some(String::from("Tone 1")),
+            price_standard: Some(50.99),
             price_sales: None,
             available: true,
             url: None,
             rating: None,
         };
         let tone_on_sale: Tone = Tone {
-            name: String::from("Tone 1"),
-            price_standard: 10.0,
+            name: Some(String::from("Tone 1")),
+            price_standard: Some(10.0),
             price_sales: Some(5.0),
             available: true,
             url: None,
@@ -609,9 +524,9 @@ mod tests {
 
         let product: Product = Product {
             name: String::from("Product 1"),
-            brand: String::from("Brand"),
+            brand: Some(String::from("Brand")),
             link: String::from("http://www.test.com"),
-            price_standard: 10.0,
+            price_standard: Some(10.0),
             price_sales: Some(5.0),
             rating: Some(9.5),
             similarity: 0.95421,
@@ -628,8 +543,8 @@ mod tests {
     #[test]
     fn tone_format_terminal_available_on_sale_with_rating() {
         let tone: Tone = Tone {
-            name: String::from("Tone 1"),
-            price_standard: 10.0,
+            name: Some(String::from("Tone 1")),
+            price_standard: Some(10.0),
             price_sales: Some(5.0),
             available: true,
             url: None,
@@ -643,8 +558,8 @@ mod tests {
     #[test]
     fn tone_format_terminal_unavailable_without_rating() {
         let tone: Tone = Tone {
-            name: String::from("Tone 1"),
-            price_standard: 10.0,
+            name: Some(String::from("Tone 1")),
+            price_standard: Some(10.0),
             price_sales: None,
             available: false,
             url: None,
@@ -657,8 +572,8 @@ mod tests {
     #[test]
     fn tone_format_terminal_unavailable_with_rating() {
         let tone: Tone = Tone {
-            name: String::from("Tone 1"),
-            price_standard: 10.0,
+            name: Some(String::from("Tone 1")),
+            price_standard: Some(10.0),
             price_sales: None,
             available: false,
             url: None,
@@ -671,8 +586,8 @@ mod tests {
     #[test]
     fn tone_format_terminal_unavailable_on_sale_without_rating() {
         let tone: Tone = Tone {
-            name: String::from("Tone 1"),
-            price_standard: 10.0,
+            name: Some(String::from("Tone 1")),
+            price_standard: Some(10.0),
             price_sales: Some(5.0),
             available: false,
             url: None,

--- a/scrapped_webs/src/scrappable.rs
+++ b/scrapped_webs/src/scrappable.rs
@@ -1,29 +1,19 @@
 //! Trait that defines the scrappable trait
+use anyhow;
 use scraper::{ElementRef, Html};
+use thiserror;
 
 use crate::product::{Product, Tone};
 
 /// Enumeration of possible error when trying to search a product.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SearchError {
-    /// Timeout in the request.
+    #[error("timeout when doing the petition.")]
     Timeout,
-    /// Found products but without enough similarity with the one provided.
+    #[error("not found any result above the minimum similarity rate.")]
     NotEnoughSimilarity,
-    /// Not found any result.
+    #[error("not found any result.")]
     NotFound,
-}
-
-impl std::fmt::Display for SearchError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SearchError::Timeout => write!(f, "timeout when doing the petition"),
-            SearchError::NotEnoughSimilarity => {
-                write!(f, "not found any result above the minimum similarity rate")
-            }
-            SearchError::NotFound => write!(f, "not found any result"),
-        }
-    }
 }
 
 pub trait Scrappable {
@@ -34,7 +24,7 @@ pub trait Scrappable {
     /// # Returns
     /// Product - A vector with the similar products that matches the name.
     /// Box<dyn Error> - If couldn't find the product.
-    fn look_for_products(&self, name: String) -> Result<Vec<Product>, SearchError>;
+    fn look_for_products(&self, name: String) -> Result<Vec<Product>, anyhow::Error>;
 
     /// Returns the url of the products found.
     /// # Arguments
@@ -43,7 +33,11 @@ pub trait Scrappable {
     /// # Returns
     /// Ok - Vector with the urls found in the search page.
     /// Err - Search error.
-    fn search_results_urls(&self, document: &Html, name: &str) -> Result<Vec<String>, SearchError>;
+    fn search_results_urls(
+        &self,
+        document: &Html,
+        name: &str,
+    ) -> Result<Vec<String>, anyhow::Error>;
 
     /// Creates and initialize the product object.
     ///
@@ -71,13 +65,13 @@ mod test {
     fn test_search_error_display() {
         assert_eq!(
             SearchError::Timeout.to_string(),
-            "timeout when doing the petition"
+            "timeout when doing the petition."
         );
         assert_eq!(
             SearchError::NotEnoughSimilarity.to_string(),
-            "not found any result above the minimum similarity rate"
+            "not found any result above the minimum similarity rate."
         );
-        assert_eq!(SearchError::NotFound.to_string(), "not found any result");
+        assert_eq!(SearchError::NotFound.to_string(), "not found any result.");
     }
 
     /// Test the search error debug implementation.

--- a/scrapped_webs/src/webs/sephora.rs
+++ b/scrapped_webs/src/webs/sephora.rs
@@ -227,13 +227,18 @@ pub mod spain {
 
             // FIXME: It is getting the number of reviews instead of the rating.
             product.rating = scrapping::inner_html_value(&html, "div.bv_numReviews_text>span>meta")
-                .ok()
-                .map(|rating| {
-                    utilities::normalized_rating(rating.parse::<f32>().unwrap(), MAX_RATING)
-                });
-            if product.rating.is_none() {
-                eprintln!("Product.rating not found, assigning None");
-            }
+                .map_or_else(
+                    |err| {
+                        eprintln!("Product.rating not found, assigning None: {:?}", err);
+                        None
+                    },
+                    |rating| {
+                        Some(utilities::normalized_rating(
+                            rating.parse::<f32>().unwrap(),
+                            MAX_RATING,
+                        ))
+                    },
+                );
 
             product
         }
@@ -257,6 +262,7 @@ pub mod spain {
                         .ok()
                         .map(utilities::parse_price_string)
                 });
+
             if price_standard.is_none() {
                 eprintln!("Tone.price_standard not found, assigning None");
             }

--- a/scrapped_webs/tests/test_maquillalia.rs
+++ b/scrapped_webs/tests/test_maquillalia.rs
@@ -66,7 +66,7 @@ mod maquillalia {
         let conf: Configuration = Configuration::new(0.95, usize::MAX);
         match Maquillalia::new(&conf).look_for_products(String::from("taemin")) {
             Ok(_) => panic!("We should not retrieve any results in this search"),
-            Err(search_error) => match search_error {
+            Err(search_error) => match search_error.downcast_ref::<SearchError>().unwrap() {
                 SearchError::Timeout => panic!("{}", search_error),
                 SearchError::NotEnoughSimilarity => panic!("{}", search_error),
                 SearchError::NotFound => assert!(true),
@@ -74,7 +74,7 @@ mod maquillalia {
         };
         match Maquillalia::new(&conf).look_for_products(String::from("iluminador facial")) {
             Ok(_) => panic!("We should not retrieve any results in this search"),
-            Err(search_error) => match search_error {
+            Err(search_error) => match search_error.downcast_ref::<SearchError>().unwrap() {
                 SearchError::Timeout => panic!("{}", search_error),
                 SearchError::NotEnoughSimilarity => assert!(true),
                 SearchError::NotFound => panic!("{}", search_error),

--- a/scrapped_webs/tests/test_maquillalia.rs
+++ b/scrapped_webs/tests/test_maquillalia.rs
@@ -91,14 +91,14 @@ mod maquillalia {
             .unwrap();
         assert_eq!(products.len(), 1);
         assert_eq!(
-            products.first().unwrap().name(),
+            products.first().unwrap().name,
             " Labial Líquido Amore Mettallics"
         );
-        assert_eq!(products.first().unwrap().brand(), "Milani ");
-        assert_eq!(products.first().unwrap().price_standard(), 0.0);
-        assert_eq!(products.first().unwrap().price_sales(), None);
-        assert_eq!(products.first().unwrap().rating(), None);
-        assert_eq!(products.first().unwrap().tones().unwrap().len(), 2);
+        assert_eq!(products.first().unwrap().brand.as_ref().unwrap(), "Milani ");
+        assert_eq!(products.first().unwrap().price_standard, None);
+        assert_eq!(products.first().unwrap().price_sales, None);
+        assert_eq!(products.first().unwrap().rating, None);
+        assert_eq!(products.first().unwrap().tones.as_ref().unwrap().len(), 2);
     }
 
     #[test]
@@ -108,11 +108,11 @@ mod maquillalia {
             .look_for_products(String::from("Agrado - Bruma facial solar SPF50+"))
             .unwrap();
         assert_eq!(products.len(), 1);
+        assert_eq!(products.first().unwrap().name, " Bruma facial solar SPF50+");
         assert_eq!(
-            products.first().unwrap().name(),
-            " Bruma facial solar SPF50+"
+            products.first().unwrap().brand.as_deref().unwrap(),
+            "Agrado ".to_string()
         );
-        assert_eq!(products.first().unwrap().brand(), "Agrado ");
-        assert_eq!(products.first().unwrap().tones().is_none(), true);
+        assert_eq!(products.first().unwrap().tones.is_none(), true);
     }
 }

--- a/scrapped_webs/tests/test_sephora.rs
+++ b/scrapped_webs/tests/test_sephora.rs
@@ -26,26 +26,50 @@ mod sephora_spain {
 
         let product = products.get(0).unwrap();
         assert_eq!(
-            *product.name(),
-            "Protector labial spf50+ - Protector labial"
+            *product.name,
+            "Protector labial spf50+ - Protector labial".to_string()
         );
-        assert_eq!(*product.brand(), "ISDIN");
+        assert_eq!(*product.brand.as_deref().unwrap(), "ISDIN".to_string());
         assert_eq!(
-            *product.link(),
+            *product.link,
             "https://www.sephora.es/p/protector-labial-spf50---protector-labial-469417.html"
+                .to_string()
         );
-        assert_eq!(product.price_standard(), 0.0);
-        assert_eq!(product.price_sales(), None);
+        assert_eq!(product.price_standard, None);
+        assert_eq!(product.price_sales, None);
         // assert_eq!(product.rating(), None); // Not assert by rating since it is changing everyday.
-        assert_eq!(product.similarity(), 1.0);
-        assert_eq!(product.tones().unwrap().len(), 1);
-        assert_eq!(*product.tones().unwrap().first().unwrap().name(), "4 g");
+        assert_eq!(product.similarity, 1.0);
+        assert_eq!(product.tones.as_ref().unwrap().len(), 1);
         assert_eq!(
-            product.tones().unwrap().first().unwrap().price_standard(),
-            7.99
+            product
+                .tones
+                .as_deref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .name
+                .as_deref()
+                .unwrap(),
+            "4 g".to_string()
         );
         assert_eq!(
-            product.tones().unwrap().first().unwrap().price_sales(),
+            product
+                .tones
+                .as_deref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .price_standard,
+            Some(7.99)
+        );
+        assert_eq!(
+            product
+                .tones
+                .as_deref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .price_sales,
             None
         );
     }

--- a/scrapped_webs/tests/test_sephora.rs
+++ b/scrapped_webs/tests/test_sephora.rs
@@ -85,7 +85,7 @@ mod sephora_spain {
 
         match sephora_spain.look_for_products(String::from("Taemin")) {
             Ok(_) => panic!("We should not find any results"),
-            Err(search_error) => match search_error {
+            Err(search_error) => match search_error.downcast_ref::<SearchError>().unwrap() {
                 SearchError::Timeout => panic!("{}", search_error),
                 SearchError::NotEnoughSimilarity => panic!("{}", search_error),
                 SearchError::NotFound => assert!(true),
@@ -93,7 +93,7 @@ mod sephora_spain {
         }
         match sephora_spain.look_for_products(String::from("iluminador facial")) {
             Ok(_) => panic!("We should not find any results"),
-            Err(search_error) => match search_error {
+            Err(search_error) => match search_error.downcast_ref::<SearchError>().unwrap() {
                 SearchError::Timeout => panic!("{}", search_error),
                 SearchError::NotEnoughSimilarity => assert!(true),
                 SearchError::NotFound => panic!("{}", search_error),

--- a/src/terminal_visualizer.rs
+++ b/src/terminal_visualizer.rs
@@ -20,7 +20,7 @@ pub fn print(results_by_website: &ResultsByWebsite) {
     for product in results_by_website.values().flatten() {
         println!();
         println!("{}", product.terminal_format());
-        if let Some(tones) = product.tones() {
+        if let Some(tones) = product.tones.as_ref() {
             for tone in tones {
                 println!("{}", tone.terminal_format());
             }
@@ -39,14 +39,27 @@ mod tests {
     /// Tests the print function.
     #[test]
     fn print_function_happy_path() {
-        let tone: Tone = Tone::new(String::from("Tone 1"), 50.99, None, true, None, None);
-        let tone_on_sale: Tone =
-            Tone::new(String::from("Tone 1"), 50.99, Some(20.0), true, None, None);
+        let tone: Tone = Tone::new(
+            Some(String::from("Tone 1")),
+            Some(50.99),
+            None,
+            true,
+            None,
+            None,
+        );
+        let tone_on_sale: Tone = Tone::new(
+            Some(String::from("Tone 1")),
+            Some(50.99),
+            Some(20.0),
+            true,
+            None,
+            None,
+        );
         let product: Product = Product::new(
             String::from("Product 1"),
-            String::from("Brand"),
+            Some(String::from("Brand")),
             String::from("http://www.test.com"),
-            10.0,
+            Some(10.0),
             Some(5.0),
             Some(vec![tone, tone_on_sale]),
             Some(0.95421),


### PR DESCRIPTION
## Description

This PR adds error handling to improve the reliability of the code and reduce the risk of runtime panics. The changes were made based on the following TODO comments:

    Added error handling to scrapping::attribute_html_value function call in add_error_handling() function.
    Replaced unwrap() with match statement to handle possible errors in scrapping::inner_html_value function call in add_error_handling() function.
    Added error handling to product.brand and product.name assignment in refactor_code() function.
    Updated name_and_brand assignment in refactor_code() function to remove trailing and beginning white spaces.
    Added error handling to product.price_standard and product.price_sales assignment in improve_code() function.

## Changes Made

    Modified add_error_handling(), refactor_code(), and improve_code() functions to add error handling.
    Removed unwrap() calls and replaced them with proper error handling.
    Updated name_and_brand assignment in refactor_code() function.

## Checklist

 Tests added for the changes
 Documentation updated
 Code formatting and linting checked
 CI checks passed